### PR TITLE
In Rails 4.2 'responders' are extracted in a separate gem and this comes with a slight change

### DIFF
--- a/entity_responder.gemspec
+++ b/entity_responder.gemspec
@@ -18,8 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "responders", "~> 2.1.0"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest-ansi"
+  spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "actionpack"
+  spec.add_development_dependency "activemodel"
 end

--- a/lib/entity_responder/version.rb
+++ b/lib/entity_responder/version.rb
@@ -1,8 +1,8 @@
 module EntityResponder
   module VERSION
-    MAJOR = 1
+    MAJOR = 2
     MINOR = 0
-    PATCH = 1
+    PATCH = 0
     STAGE = nil
 
     def self.to_s

--- a/lib/responders/entity_responder.rb
+++ b/lib/responders/entity_responder.rb
@@ -3,8 +3,9 @@ module Responders
     protected
 
     # This is the common behavior for formats associated with APIs, such as :xml and :json.
-    def api_behavior(error)
-      raise error unless resourceful?
+    def api_behavior
+      raise MissingRenderer.new(format) unless has_renderer?
+
       if !get? && !post?
         display resource, :status => :ok, :location => api_location
       else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,16 +1,16 @@
+require 'bundler/setup'
 require 'minitest/autorun'
-require 'bundler'
-
-Bundler.setup
 
 # Configure Rails
 ENV["RAILS_ENV"] = "test"
 
-require 'minitest/ansi'
-MiniTest::ANSI.use!
+require 'minitest/reporters'
+Minitest::Reporters.use!
 
+require 'active_model'
 require 'action_controller'
 require 'action_controller/test_case'
+require 'responders'
 require 'entity_responder'
 
 Routes = ActionDispatch::Routing::RouteSet.new
@@ -20,6 +20,7 @@ end
 
 class ActiveSupport::TestCase
   setup do @routes = Routes end
+  self.test_order = :random
 end
 
 class AppResponder < ActionController::Responder


### PR DESCRIPTION
* api_behavior method now takes zero params
* minitest-ansi does not support minitest > v5 - replaced with minitest-reporters
* included active_model for testing